### PR TITLE
Reduce duplicate events with some array operations

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -2,8 +2,8 @@
 'use strict';
 const onChange = require('..');
 
-const save = object => {
-	let i = object.a;
+const save = (object, initial = 0) => {
+	let i = object[initial];
 	while (i < 1000) {
 		i++;
 	}
@@ -18,7 +18,7 @@ suite('onChange', () => {
 			b: 0,
 			c: 0,
 			d: 0
-		}, () => save(foo));
+		}, () => save(foo, 'a'));
 
 		foo.a = 1;
 		foo.b = 2;
@@ -35,12 +35,38 @@ suite('onChange', () => {
 		};
 
 		foo.a = 1;
-		save(foo);
+		save(foo, 'a');
 		foo.b = 2;
-		save(foo);
+		save(foo, 'a');
 		foo.c = 3;
-		save(foo);
+		save(foo, 'a');
 		foo.d = 4;
+		save(foo, 'a');
+	});
+});
+
+suite('bench with an array too', () => {
+	set('mintime', 5000);
+
+	bench('on-change', () => {
+		const foo = onChange([0, 0, 0, 0], () => save(foo));
+
+		foo[0] = 1;
+		foo[1] = 2;
+		foo[2] = 3;
+		foo[3] = 4;
+	});
+
+	bench('native', () => {
+		const foo = [0, 0, 0, 0];
+
+		foo[0] = 1;
+		save(foo);
+		foo[1] = 2;
+		save(foo);
+		foo[2] = 3;
+		save(foo);
+		foo[3] = 4;
 		save(foo);
 	});
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BLACKLIST = [
+const blacklist = [
 	'sort',
 	'reverse',
 	'splice',
@@ -9,8 +9,10 @@ const BLACKLIST = [
 	'shift',
 	'push'
 ];
+
 module.exports = (object, onChange) => {
-	let blocked = false;
+	let isBlocked = false;
+
 	const handler = {
 		get(target, property, receiver) {
 			try {
@@ -22,7 +24,7 @@ module.exports = (object, onChange) => {
 		defineProperty(target, property, descriptor) {
 			const result = Reflect.defineProperty(target, property, descriptor);
 
-			if (!blocked) {
+			if (!isBlocked) {
 				onChange();
 			}
 
@@ -31,20 +33,21 @@ module.exports = (object, onChange) => {
 		deleteProperty(target, property) {
 			const result = Reflect.deleteProperty(target, property);
 
-			if (!blocked) {
+			if (!isBlocked) {
 				onChange();
 			}
 
 			return result;
 		},
 		apply(target, thisArg, argumentsList) {
-			if (BLACKLIST.includes(target.name)) {
-				blocked = true;
+			if (blacklist.includes(target.name)) {
+				isBlocked = true;
 				const result = Reflect.apply(target, thisArg, argumentsList);
 				onChange();
-				blocked = false;
+				isBlocked = false;
 				return result;
 			}
+
 			return Reflect.apply(target, thisArg, argumentsList);
 		}
 	};

--- a/index.js
+++ b/index.js
@@ -32,17 +32,14 @@ module.exports = (object, onChange) => {
 			return Reflect.deleteProperty(target, property);
 		},
 		apply(target, thisArg, argumentsList) {
-			let fn = target;
 			if (BLACKLIST.includes(target.name)) {
 				blocked = true;
-				fn = () => {
-					const result = target.call(thisArg, argumentsList);
-					blocked = false;
-					return result;
-				};
+				const result = target.call(thisArg, argumentsList);
 				onChange();
+				blocked = false;
+				return result;
 			}
-			return Reflect.apply(fn, thisArg, argumentsList);
+			return Reflect.apply(target, thisArg, argumentsList);
 		}
 	};
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = (object, onChange) => {
 		apply(target, thisArg, argumentsList) {
 			if (BLACKLIST.includes(target.name)) {
 				blocked = true;
-				const result = target.call(thisArg, argumentsList);
+				const result = Reflect.apply(target, thisArg, argumentsList);
 				onChange();
 				blocked = false;
 				return result;

--- a/test.js
+++ b/test.js
@@ -58,8 +58,17 @@ test('works with an array too', t => {
 	t.is(callCount, 2);
 
 	array.sort();
-	t.is(callCount, 6);
+	t.is(callCount, 3);
 
 	array.pop();
-	t.is(callCount, 8);
+	t.is(callCount, 4);
+
+	array[2] = false;
+	t.is(callCount, 5);
+
+	array.reverse();
+	t.is(callCount, 6);
+
+	array.reverse();
+	t.is(callCount, 7);
 });


### PR DESCRIPTION
This PR fixes #7 , uses the `apply` trap to prevent multiple calls to `onChange` on Array blacklisted methods.

I blacklisted all methods mentioned on the issue. I'm open to suggestions if you think there's a better way to determine which method needs to be prevented.