### PR TITLE
Preserve proxy invariants

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,72 +1,99 @@
-/* globals suite set bench */
+/* globals suite set bench before */
 'use strict';
 const onChange = require('..');
 
-const save = (object, initial = 0) => {
-	let i = object[initial];
-	while (i < 1000) {
-		i++;
-	}
-};
+const save = () => {};
 
-suite('onChange', () => {
+suite('on-change', () => {
 	set('mintime', 5000);
 
-	bench('on-change', () => {
-		const foo = onChange({
+	let val = 0;
+
+	before(() => {
+		this.object = onChange({
 			a: 0,
 			b: 0,
 			c: 0,
-			d: 0
-		}, () => save(foo, 'a'));
-
-		foo.a = 1;
-		foo.b = 2;
-		foo.c = 3;
-		foo.d = 4;
+			d: 0,
+			subObj: {a: 0}
+		}, save);
+		this.array = onChange([0, 0, 0, 0], save);
 	});
 
-	bench('native', () => {
-		const foo = {
-			a: 0,
-			b: 0,
-			c: 0,
-			d: 0
-		};
+	bench('object read', () => {
+		this.object.a === val++; // eslint-disable-line no-unused-expressions
+	});
 
-		foo.a = 1;
-		save(foo, 'a');
-		foo.b = 2;
-		save(foo, 'a');
-		foo.c = 3;
-		save(foo, 'a');
-		foo.d = 4;
-		save(foo, 'a');
+	bench('nested read', () => {
+		this.object.subObj.a === val++; // eslint-disable-line no-unused-expressions
+	});
+
+	bench('array read', () => {
+		this.array[0] === val++; // eslint-disable-line no-unused-expressions
+	});
+
+	bench('object write', () => {
+		this.object.a = val++;
+		this.object.b = val++;
+		this.object.c = val++;
+		this.object.d = val++;
+	});
+
+	bench('array write', () => {
+		this.array[0] = val++;
+		this.array[1] = val++;
+		this.array[2] = val++;
+		this.array[3] = val++;
 	});
 });
 
-suite('bench with an array too', () => {
+suite('native', () => {
 	set('mintime', 5000);
 
-	bench('on-change', () => {
-		const foo = onChange([0, 0, 0, 0], () => save(foo));
+	let val = 0;
 
-		foo[0] = 1;
-		foo[1] = 2;
-		foo[2] = 3;
-		foo[3] = 4;
+	before(() => {
+		this.object = {
+			a: 0,
+			b: 0,
+			c: 0,
+			d: 0,
+			subObj: {a: 0}
+		};
+		this.array = [0, 0, 0, 0];
 	});
 
-	bench('native', () => {
-		const foo = [0, 0, 0, 0];
+	bench('object read', () => {
+		this.object.a === val++; // eslint-disable-line no-unused-expressions
+	});
 
-		foo[0] = 1;
-		save(foo);
-		foo[1] = 2;
-		save(foo);
-		foo[2] = 3;
-		save(foo);
-		foo[3] = 4;
-		save(foo);
+	bench('nested read', () => {
+		this.object.subObj.a === val++; // eslint-disable-line no-unused-expressions
+	});
+
+	bench('array read', () => {
+		this.array[0] === val++; // eslint-disable-line no-unused-expressions
+	});
+
+	bench('object write', () => {
+		this.object.a = val++;
+		save();
+		this.object.b = val++;
+		save();
+		this.object.c = val++;
+		save();
+		this.object.d = val++;
+		save();
+	});
+
+	bench('array write', () => {
+		this.array[0] = val++;
+		save();
+		this.array[1] = val++;
+		save();
+		this.array[2] = val++;
+		save();
+		this.array[3] = val++;
+		save();
 	});
 });

--- a/index.js
+++ b/index.js
@@ -26,12 +26,10 @@ module.exports = (object, onChange) => {
 					return value;
 				}
 			}
-
-			try {
+			if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
 				return new Proxy(value, handler);
-			} catch (_) {
-				return value;
 			}
+			return value;
 		},
 		set(target, property, value) {
 			const result = Reflect.set(target, property, value);

--- a/index.js
+++ b/index.js
@@ -14,10 +14,13 @@ module.exports = (object, onChange) => {
 
 	const handler = {
 		get(target, property, receiver) {
-			const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
 			const value = Reflect.get(target, property, receiver);
+			if (value === null || (typeof value !== 'object' && typeof value !== 'function')) {
+				return value;
+			}
 
 			// Preserve invariants
+			const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
 			if (descriptor && !descriptor.configurable) {
 				if (descriptor.set && !descriptor.get) {
 					return undefined;
@@ -26,10 +29,8 @@ module.exports = (object, onChange) => {
 					return value;
 				}
 			}
-			if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
-				return new Proxy(value, handler);
-			}
-			return value;
+
+			return new Proxy(value, handler);
 		},
 		set(target, property, value) {
 			const result = Reflect.set(target, property, value);

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = (object, onChange) => {
 			return new Proxy(value, handler);
 		},
 		set(target, property, value, receiver) {
-			if (value[proxyTarget] !== undefined) {
+			if (value && value[proxyTarget] !== undefined) {
 				value = value[proxyTarget];
 			}
 			const previous = Reflect.get(target, property, value, receiver);

--- a/test.js
+++ b/test.js
@@ -39,6 +39,14 @@ test('main', t => {
 	object.bar.a.c[2] = 5;
 	t.is(object.bar.a.c[2], 5);
 	t.is(callCount, 6);
+
+	object.bar.a.c[2] = 5;
+	t.is(callCount, 6);
+
+	// Unwrap proxies on assignment
+	const prev = fixture.bar.a;
+	object.bar.a = object.bar.a; // eslint-disable-line no-self-assign
+	t.is(fixture.bar.a, prev);
 });
 
 test('works with an array too', t => {

--- a/test.js
+++ b/test.js
@@ -30,6 +30,7 @@ test('main', t => {
 	t.is(callCount, 3);
 
 	delete object.foo;
+	t.is(object.foo, undefined);
 	t.is(callCount, 4);
 
 	object.bar.a.b = 1;
@@ -47,6 +48,16 @@ test('main', t => {
 	const prev = fixture.bar.a;
 	object.bar.a = object.bar.a; // eslint-disable-line no-self-assign
 	t.is(fixture.bar.a, prev);
+
+	// Support null assignment
+	object.bar.a.c[2] = null;
+	t.is(object.bar.a.c[2], null);
+	t.is(callCount, 7);
+
+	// Support undefined assignment
+	object.bar.a.c[2] = undefined;
+	t.is(object.bar.a.c[2], undefined);
+	t.is(callCount, 8);
 });
 
 test('works with an array too', t => {

--- a/test.js
+++ b/test.js
@@ -50,35 +50,43 @@ test('works with an array too', t => {
 		callCount++;
 	});
 	array[0] = 'a';
-	t.deepEqual(array, ['a', 2, {a: false}]);
+	t.deepEqual(fixture, ['a', 2, {a: false}]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 1);
 
 	array[2].a = true;
-	t.deepEqual(array, ['a', 2, {a: true}]);
+	t.deepEqual(fixture, ['a', 2, {a: true}]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 2);
 
 	array.sort();
-	t.deepEqual(array, [2, {a: true}, 'a']);
+	t.deepEqual(fixture, [2, {a: true}, 'a']);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 3);
 
 	array.pop();
-	t.deepEqual(array, [2, {a: true}]);
+	t.deepEqual(fixture, [2, {a: true}]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 4);
 
 	array[2] = false;
-	t.deepEqual(array, [2, {a: true}, false]);
+	t.deepEqual(fixture, [2, {a: true}, false]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 5);
 
 	array.reverse();
-	t.deepEqual(array, [false, {a: true}, 2]);
+	t.deepEqual(fixture, [false, {a: true}, 2]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 6);
 
 	array.reverse();
-	t.deepEqual(array, [2, {a: true}, false]);
+	t.deepEqual(fixture, [2, {a: true}, false]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 7);
 
 	array.splice(1, 1, 'a', 'b');
-	t.deepEqual(array, [2, 'a', 'b', false]);
+	t.deepEqual(fixture, [2, 'a', 'b', false]);
+	t.deepEqual(array, fixture);
 	t.is(callCount, 8);
 });
 


### PR DESCRIPTION
Preserve invariants specified in

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get#Invariants

Based on https://github.com/sindresorhus/on-change/pull/15
Based on https://github.com/sindresorhus/on-change/pull/8

Also add full support for accessor properties.