### PR TITLE
Should return the original constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+\.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-\.idea/

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = (object, onChange) => {
 			}
 
 			const value = Reflect.get(target, property, receiver);
-			if (isPrimitive(value)) {
+			if (isPrimitive(value) || property === 'constructor') {
 				return value;
 			}
 
@@ -63,10 +63,6 @@ module.exports = (object, onChange) => {
 				if (descriptor.writable === false) {
 					return value;
 				}
-			}
-
-			if (property === 'constructor') {
-				return value;
 			}
 
 			return new Proxy(value, handler);

--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ module.exports = (object, onChange) => {
 				}
 			}
 
+			if (property === 'constructor') {
+				return value;
+			}
+
 			return new Proxy(value, handler);
 		},
 

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ test('main', t => {
 	});
 
 	object.foo = true;
+	t.is(object.constructor, Object);
 	t.is(callCount, 1);
 
 	Object.defineProperty(object, 'newProp', {


### PR DESCRIPTION
Many libraries like Lodash have an isObject function that would fail on an object with onChange applied, this would fix that.