### PR TITLE
Cache proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const onChange = (object, onChange, options = {}) => {
 	let changed = false;
 	const propCache = new WeakMap();
 	const pathCache = new WeakMap();
+	const proxyCache = new WeakMap();
 
 	const handleChange = (path, property, previous, value) => {
 		if (!inApply) {
@@ -81,7 +82,13 @@ const onChange = (object, onChange, options = {}) => {
 			}
 
 			pathCache.set(value, concatPath(pathCache.get(target), property));
-			return new Proxy(value, handler);
+			let proxy = proxyCache.get(value);
+			if (proxy === undefined) {
+				proxy = new Proxy(value, handler);
+				proxyCache.set(value, proxy);
+			}
+
+			return proxy;
 		},
 
 		set(target, property, value, receiver) {


### PR DESCRIPTION
Reuse previously created proxies where possible. This does not meaningfully change performance of the benchmarks, but in some real-world testing I've observed that it **significantly** reduces GC pressure when the same properties are accessed a lot.