### PR TITLE
Return Dates and RegExps as primitives.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const isPrimitive = value => value === null || (typeof value !== 'object' && typeof value !== 'function');
+const isPrimitive = value => {
+	const type = typeof value;
+	return value === null ||
+		value instanceof Date ||
+		value instanceof RegExp ||
+		(type !== 'object' && type !== 'function');
+};
 
 const concatPath = (path, property) => {
 	if (property && property.toString) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import onChange from '.';
 
+const testValues = [null, undefined, 'string', true, /regexp/, new Date(), NaN, Infinity];
+
 test('main', t => {
 	const fixture = {
 		foo: false,
@@ -50,15 +52,11 @@ test('main', t => {
 	object.bar.a = object.bar.a; // eslint-disable-line no-self-assign
 	t.is(fixture.bar.a, prev);
 
-	// Support null assignment
-	object.bar.a.c[2] = null;
-	t.is(object.bar.a.c[2], null);
-	t.is(callCount, 7);
-
-	// Support undefined assignment
-	object.bar.a.c[2] = undefined;
-	t.is(object.bar.a.c[2], undefined);
-	t.is(callCount, 8);
+	testValues.forEach((value, index) => {
+		object.bar.a.c[2] = value;
+		t.is(object.bar.a.c[2], value);
+		t.is(callCount, 7 + index);
+	});
 });
 
 test('works with an array too', t => {


### PR DESCRIPTION
Dates and RegExps should be handled like primitives, but the current isPrimitive function wasn't handling them. Fixes #25 