### PR TITLE
Add useful parameters to 'onChange' callback after method calls.

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -59,8 +59,8 @@ suite('on-change shallow', () => {
 			c: 0,
 			d: 0,
 			subObj: {a: 0}
-		}, save, true);
-		this.array = onChange([0, 0, 0, 0], save, true);
+		}, save, {isShallow: true});
+		this.array = onChange([0, 0, 0, 0], save, {isShallow: true});
 	});
 
 	bench('object read', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare namespace onChange {
 		*/
 		readonly isShallow?: boolean;
 		/**
-		 A function that should return a clone of a value. Enables the "previous" value in the onChange callback when array methods are called.
+		A function that should return a clone of a value. Enables the "previous" value in the onChange callback when array methods are called.
 		*/
 		readonly clone?: Function;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,10 @@ declare namespace onChange {
 		```
 		*/
 		readonly isShallow?: boolean;
+		/**
+		 A function that should return a clone of a value. Enables the "previous" value in the onChange callback when array methods are called.
+		*/
+		readonly clone?: Function;
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Function that gets called anytime the object changes.
 The function receives three arguments:
 1. A path to the value that was changed. A change to `c` in the above example would return `a.b.0.c`.
 2. The new value at the path.
-3. The previous value at the path. For array method calls, the previous value is undefined unless options.clone is set.
+3. The previous value at the path. For array method calls, the previous value is `undefined` unless `options.clone` is set.
 
 The context (this) is set to the original object passed to `onChange` (with Proxy).
 

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Function that gets called anytime the object changes.
 The function receives three arguments:
 1. A path to the value that was changed. A change to `c` in the above example would return `a.b.0.c`.
 2. The new value at the path.
-3. The previous value at the path.
+3. The previous value at the path. For array method calls, the previous value is undefined unless options.clone is set.
 
 The context (this) is set to the original object passed to `onChange` (with Proxy).
 
@@ -108,6 +108,12 @@ Type: `boolean`<br>
 Default: `false`
 
 Deep changes will not trigger the callback. Only changes to the immediate properties of the original object.
+
+##### clone
+
+Type: `function`
+
+A function that should return a clone of a value. Enables the "previous" value in the onChange callback when array methods are called.
 
 
 ## Use-case


### PR DESCRIPTION
Fixes #24. All method calls are treated as modifying the item that the method belongs to, so pushing to an array will trigger a callback for the array, not the item pushed to it. Due to the overhead of cloning, I'm returning undefined for the 'previous' value in these cases, but I've also added an option where the user can provide their own clone function if they need that functionality.