### PR TITLE
Don't proxy `RegExp` and `Number`, detect changes to `Date`

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,10 +68,12 @@ const onChange = (object, onChange, options = {}) => {
 			}
 
 			const value = Reflect.get(target, property, receiver);
-			if (isPrimitive(value) ||
+			if (
+				isPrimitive(value) ||
 				isBuiltinWithoutMutableMethods(value) ||
 				property === 'constructor' ||
-				options.isShallow === true) {
+				options.isShallow === true
+			) {
 				return value;
 			}
 

--- a/test.js
+++ b/test.js
@@ -55,7 +55,7 @@ test('main', t => {
 	t.is(fixture.bar.a, prev);
 });
 
-testValues.forEach((value, index) => {
+for (const [index, value] of testValues.entries()) {
 	test(`should handle '${value}' (testValues[${index}])`, t => {
 		const fixture = {
 			a: 0,
@@ -82,9 +82,9 @@ testValues.forEach((value, index) => {
 		object.b[2] = value;
 		t.is(callCount, 2);
 	});
-});
+}
 
-test('Dates', t => {
+test('dates', t => {
 	let callCount = 0;
 	const object = onChange({
 		a: 0


### PR DESCRIPTION
Fixes #25. This fix still returns a proxied date, so comparing a proxied date to the original date will still return false, but calling the methods on the proxied date should work as expected now.