### PR TITLE
Add ignoreKeys and ignoreUnderscores

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,20 @@ declare namespace onChange {
 		@default false
 		*/
 		ignoreSymbols?: boolean;
+
+		/**
+		Setting properties in this array won't trigger the callback.
+
+		@default undefined
+		*/
+		ignoreKeys?: Array<string|symbol>;
+
+		/**
+		Setting properties with an underscore as the first character won't trigger the callback.
+
+		@default false
+		*/
+		ignoreUnderscores?: boolean;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -152,8 +152,11 @@ const onChange = (object, onChange, options = {}) => {
 		return target;
 	};
 
-	const ignoreChange = property => {
-		return isUnsubscribed || (options.ignoreSymbols === true && typeof property === 'symbol');
+	const ignoreProperty = property => {
+		return isUnsubscribed ||
+			(options.ignoreSymbols === true && typeof property === 'symbol') ||
+			(options.ignoreUnderscores === true && property.charAt(0) === '_') ||
+			(options.ignoreKeys !== undefined && options.ignoreKeys.includes(property));
 	};
 
 	const handler = {
@@ -174,7 +177,7 @@ const onChange = (object, onChange, options = {}) => {
 				isBuiltinWithoutMutableMethods(value) ||
 				property === 'constructor' ||
 				options.isShallow === true ||
-				(options.ignoreKeys && options.ignoreKeys.includes(property))
+				ignoreProperty(property)
 			) {
 				return value;
 			}
@@ -199,7 +202,7 @@ const onChange = (object, onChange, options = {}) => {
 				value = value[proxyTarget];
 			}
 
-			const ignore = ignoreChange(property);
+			const ignore = ignoreProperty(property);
 			const previous = ignore ? null : Reflect.get(target, property, receiver);
 			const isChanged = !(property in target) || !equals(previous, value);
 			let result = true;
@@ -221,7 +224,7 @@ const onChange = (object, onChange, options = {}) => {
 			if (!isSameDescriptor(descriptor, getOwnPropertyDescriptor(target, property))) {
 				result = Reflect.defineProperty(target, property, descriptor);
 
-				if (result && !ignoreChange(property) && !isSameDescriptor()) {
+				if (result && !ignoreProperty(property) && !isSameDescriptor()) {
 					invalidateCachedDescriptor(target, property);
 
 					handleChange(pathCache.get(target), property, undefined, descriptor.value);
@@ -236,7 +239,7 @@ const onChange = (object, onChange, options = {}) => {
 				return true;
 			}
 
-			const ignore = ignoreChange(property);
+			const ignore = ignoreProperty(property);
 			const previous = ignore ? null : Reflect.get(target, property);
 			const result = Reflect.deleteProperty(target, property);
 

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ const onChange = (object, onChange, options = {}) => {
 				isBuiltinWithoutMutableMethods(value) ||
 				property === 'constructor' ||
 				options.isShallow === true ||
-				property === '__ob__'
+				options.ignoreKeys.includes(property)
 			) {
 				return value;
 			}

--- a/index.js
+++ b/index.js
@@ -173,7 +173,8 @@ const onChange = (object, onChange, options = {}) => {
 				isPrimitive(value) ||
 				isBuiltinWithoutMutableMethods(value) ||
 				property === 'constructor' ||
-				options.isShallow === true
+				options.isShallow === true ||
+				property === '__ob__'
 			) {
 				return value;
 			}

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ const onChange = (object, onChange, options = {}) => {
 				isBuiltinWithoutMutableMethods(value) ||
 				property === 'constructor' ||
 				options.isShallow === true ||
-				options.ignoreKeys.includes(property)
+				(options.ignoreKeys && options.ignoreKeys.includes(property))
 			) {
 				return value;
 			}

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 		"listener"
 	],
 	"devDependencies": {
-		"ava": "^3.4.0",
-		"display-value": "^1.3.2",
+		"ava": "^3.5.0",
+		"display-value": "^1.6.0",
 		"matcha": "^0.7.0",
 		"tsd": "^0.11.0",
 		"xo": "^0.27.2"

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,20 @@ Default: false
 
 Setting properties as `Symbol` won't trigger the callback.
 
+##### ignoreKeys
+
+Type: `Array<string|symbol>`<br>
+Default: undefined
+
+Setting properties in this array won't trigger the callback.
+
+##### ignoreUnderscores
+
+Type: `boolean`<br>
+Default: false
+
+Setting properties with an underscore as the first character won't trigger the callback.
+
 ### onChange.target(object)
 
 Returns the original unwatched object.

--- a/test.js
+++ b/test.js
@@ -25,16 +25,16 @@ const testHelper = (t, object, options, callback) => {
 
 	// eslint-disable-next-line max-params
 	const verify = (count, thisArg, path, value, previous, fullObject) => {
-		t.is(last.count, count);
-		t.is(last.thisArg, thisArg);
-		t.deepEqual(last.path, path);
-		t.deepEqual(last.value, value);
-		t.deepEqual(last.previous, previous);
+		t.is(count, last.count);
+		t.is(thisArg, last.thisArg);
+		t.deepEqual(path, last.path);
+		t.deepEqual(value, last.value);
+		t.deepEqual(previous, last.previous);
 
-		t.is(onChange.target(proxy), object);
+		t.is(object, onChange.target(proxy));
 
 		if (fullObject !== undefined) {
-			t.deepEqual(object, fullObject);
+			t.deepEqual(fullObject, object);
 			t.deepEqual(proxy, object);
 		}
 	};
@@ -386,7 +386,7 @@ test('the callback should return a raw value when apply traps are triggered', t 
 	});
 });
 
-test('the callback should trigger when a Symbol is used as the key and ignoreSymbols is not set', t => {
+test('should trigger the callback when a Symbol is used as the key and ignoreSymbols is not set', t => {
 	const object = {
 		x: {
 			y: [{
@@ -418,7 +418,7 @@ test('the callback should trigger when a Symbol is used as the key and ignoreSym
 	});
 });
 
-test('the callback should not trigger when a Symbol is used as the key and ignoreSymbols is true', t => {
+test('should not trigger the callback when a Symbol is used as the key and ignoreSymbols is true', t => {
 	const object = {
 		x: {
 			y: [{
@@ -430,8 +430,16 @@ test('the callback should not trigger when a Symbol is used as the key and ignor
 	testHelper(t, object, {ignoreSymbols: true}, (proxy, verify) => {
 		const SYMBOL = Symbol('test');
 		const SYMBOL2 = Symbol('test2');
+		const object2 = {
+			c: 2
+		};
 
-		proxy[SYMBOL] = true;
+		proxy[SYMBOL] = object2;
+		verify(0);
+
+		t.is(proxy[SYMBOL], object2);
+
+		proxy[SYMBOL].c = 3;
 		verify(0);
 
 		Object.defineProperty(proxy, SYMBOL2, {
@@ -443,6 +451,82 @@ test('the callback should not trigger when a Symbol is used as the key and ignor
 		verify(0);
 
 		delete proxy[SYMBOL2];
+		verify(0);
+
+		proxy.z = true;
+		verify(1, proxy, 'z', true, undefined);
+	});
+});
+
+test('should not trigger the callback when a key is used that is in ignoreKeys', t => {
+	const object = {
+		x: {
+			y: [{
+				z: 0
+			}]
+		}
+	};
+
+	testHelper(t, object, {ignoreKeys: ['a', 'b']}, (proxy, verify) => {
+		const object2 = {
+			c: 2
+		};
+
+		proxy.a = object2;
+		verify(0);
+
+		t.is(proxy.a, object2);
+
+		proxy.a.c = 3;
+		verify(0);
+
+		Object.defineProperty(proxy, 'b', {
+			value: true,
+			configurable: true,
+			writable: true,
+			enumerable: false
+		});
+		verify(0);
+
+		delete proxy.b;
+		verify(0);
+
+		proxy.z = true;
+		verify(1, proxy, 'z', true, undefined);
+	});
+});
+
+test('should not trigger the callback when a key with an underscore is used and ignoreUnderscores is true', t => {
+	const object = {
+		x: {
+			y: [{
+				z: 0
+			}]
+		}
+	};
+
+	testHelper(t, object, {ignoreUnderscores: true}, (proxy, verify) => {
+		const object2 = {
+			c: 2
+		};
+
+		proxy._a = object2;
+		verify(0);
+
+		t.is(proxy._a, object2);
+
+		proxy._a.c = 3;
+		verify(0);
+
+		Object.defineProperty(proxy, '_b', {
+			value: true,
+			configurable: true,
+			writable: true,
+			enumerable: false
+		});
+		verify(0);
+
+		delete proxy._b;
 		verify(0);
 
 		proxy.z = true;


### PR DESCRIPTION
If the property is `__ob__` which is what vue uses for its observable nonsense then we just skip traversing it.