### PR TITLE
Fix TypeScript definition when pathAsArray is true

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,7 +192,20 @@ declare const onChange: {
 			previousValue: unknown,
 			name: string
 		) => void,
-		options?: onChange.Options
+		options?: onChange.Options & {pathAsArray?: false}
+	): ObjectType;
+
+	// Overload that returns an Array as path when pathAsArray is true
+	<ObjectType extends {[key: string]: any}>(
+		object: ObjectType,
+		onChange: (
+			this: ObjectType,
+			path: Array<string|symbol>,
+			value: unknown,
+			previousValue: unknown,
+			name: string
+		) => void,
+		options: onChange.Options & {pathAsArray: true}
 	): ObjectType;
 
 	/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,8 +12,9 @@ const object = {
 	}
 };
 
-const watchedObject = onChange(object, function () {
+const watchedObject = onChange(object, function (path) {
 	expectType<typeof object>(this);
+	expectType<string>(path);
 });
 expectType<typeof object>(watchedObject);
 
@@ -37,3 +38,22 @@ const watchedObjectEquals = onChange(object, function () {
 expectType<typeof object>(watchedObjectEquals);
 
 watchedObject.foo = true;
+
+const watchedObjectPathAsArray = onChange(object, function (path) {
+	expectType<typeof object>(this);
+	expectType<Array<string|symbol>>(path);
+}, {
+	pathAsArray: true
+});
+expectType<typeof object>(watchedObjectPathAsArray);
+watchedObjectPathAsArray.foo = true;
+
+const watchedObjectPathAsString = onChange(object, function (path) {
+	expectType<typeof object>(this);
+	expectType<string>(path);
+}, {
+	pathAsArray: false
+});
+expectType<typeof object>(watchedObjectPathAsString);
+
+watchedObjectPathAsString.foo = true;


### PR DESCRIPTION
Fixes #65
Not sure if this is the most elegant way to handle the different paramter types that depend on a value in options.
Also the first time using tsd for tests, so I hope the added test cases are useful.