### PR TITLE
fix: Array.prototype iterator functions in browser based environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,10 @@ const onChange = (object, onChange, options = {}) => {
 			return !isValid;
 		},
 
+		has(target, property) {
+			return Reflect.has(target, property);
+		},
+
 		defineProperty(target, property, descriptor) {
 			if (!cache.isSameDescriptor(descriptor, target, property)) {
 				const previous = target[property];


### PR DESCRIPTION
Most of the Array.protoype functions which iterate over the arrays like Array.prototype.forEach() or Array.prototype.forEach() do not work on the proxied objects in browser based environment due to a missing `has` handler in the `Proxy` definition. A detailled description of the problem can be found in #94. This fixes #94.