### PR TITLE
fix(typescript): overload when `ignoreSymbols` and `pathAsArray` are true

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,12 +259,12 @@ declare const onChange: {
 		object: ObjectType,
 		onChange: (
 			this: ObjectType,
-			path: Array<string>,
+			path: string[],
 			value: unknown,
 			previousValue: unknown,
 			applyData: ApplyData
 		) => void,
-		options: Options & {ignoreSymbols: true, pathAsArray: true}
+		options: Options & {ignoreSymbols: true; pathAsArray: true}
 	): ObjectType;
 
 	// Overload that returns an Array as path when `pathAsArray` option is true.

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,7 +254,7 @@ declare const onChange: {
 		options?: Options & {pathAsArray?: false}
 	): ObjectType;
 
-	// Overload that returns a String Array as path when `ignoreSymbols` and `pathAsArray` options are true.
+	// Overload that returns a string array as path when `ignoreSymbols` and `pathAsArray` options are true.
 	<ObjectType extends Record<string, any>>(
 		object: ObjectType,
 		onChange: (
@@ -267,7 +267,7 @@ declare const onChange: {
 		options: Options & {ignoreSymbols: true; pathAsArray: true}
 	): ObjectType;
 
-	// Overload that returns an Array as path when `pathAsArray` option is true.
+	// Overload that returns an array as path when `pathAsArray` option is true.
 	<ObjectType extends Record<string, any>>(
 		object: ObjectType,
 		onChange: (

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,6 +254,19 @@ declare const onChange: {
 		options?: Options & {pathAsArray?: false}
 	): ObjectType;
 
+	// Overload that returns a String Array as path when `ignoreSymbols` and `pathAsArray` options are true.
+	<ObjectType extends Record<string, any>>(
+		object: ObjectType,
+		onChange: (
+			this: ObjectType,
+			path: Array<string>,
+			value: unknown,
+			previousValue: unknown,
+			applyData: ApplyData
+		) => void,
+		options: Options & {ignoreSymbols: true, pathAsArray: true}
+	): ObjectType;
+
 	// Overload that returns an Array as path when `pathAsArray` option is true.
 	<ObjectType extends Record<string, any>>(
 		object: ObjectType,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -60,7 +60,7 @@ watchedObjectPathAsString.foo = true;
 
 const watchedObjectPathAsStringArray = onChange(object, function (path) {
 	expectType<typeof object>(this);
-	expectType<Array<string>>(path);
+	expectType<string[]>(path);
 }, {
 	ignoreSymbols: true,
 	pathAsArray: true,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -57,3 +57,14 @@ const watchedObjectPathAsString = onChange(object, function (path) {
 expectType<typeof object>(watchedObjectPathAsString);
 
 watchedObjectPathAsString.foo = true;
+
+const watchedObjectPathAsStringArray = onChange(object, function (path) {
+	expectType<typeof object>(this);
+	expectType<Array<string>>(path);
+}, {
+	ignoreSymbols: true,
+	pathAsArray: true,
+});
+expectType<typeof object>(watchedObjectPathAsStringArray);
+
+watchedObjectPathAsStringArray.foo = true;


### PR DESCRIPTION
First of all, thank you for making this handy library, I love it!

I noticed there's no overload when both the options are true, making the path type wrong when using TypeScript.