### PR TITLE
Fixed incorrect changed path when mutating unrelated area of proxy during iteration operations on cloned areas of the proxy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const onChange = (object, onChange, options = {}) => {
 
 	// eslint-disable-next-line max-params
 	const handleChange = (changePath, property, value, previous, applyData) => {
-		if (smartClone.isCloning) {
+		if (smartClone.isCloning && smartClone.isPartOfClone(changePath)) {
 			smartClone.update(changePath, property, previous);
 		} else {
 			onChange(path.concat(changePath, property), value, previous, applyData);

--- a/lib/path.js
+++ b/lib/path.js
@@ -107,6 +107,42 @@ const path = {
 
 		return object;
 	},
+	isSubPath(path, subPath) {
+		if (isArray(path)) {
+			if (path.length < subPath.length) {
+				return false;
+			}
+
+			for (let i = 0; i < subPath.length; i++) {
+				if (path[i] !== subPath[i]) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		if (path.length < subPath.length) {
+			return false;
+		}
+
+		if (path === subPath) {
+			return true;
+		}
+
+		if (path.indexOf(subPath) === 0) {
+			return path[subPath.length] === PATH_SEPARATOR;
+		}
+
+		return false;
+	},
+	isRootPath(path) {
+		if (isArray(path)) {
+			return path.length === 0;
+		}
+
+		return path === '';
+	},
 };
 
 export default path;

--- a/lib/path.js
+++ b/lib/path.js
@@ -113,6 +113,7 @@ const path = {
 				return false;
 			}
 
+			// eslint-disable-next-line unicorn/no-for-loop
 			for (let i = 0; i < subPath.length; i++) {
 				if (path[i] !== subPath[i]) {
 					return false;

--- a/lib/path.js
+++ b/lib/path.js
@@ -131,7 +131,7 @@ const path = {
 			return true;
 		}
 
-		if (path.indexOf(subPath) === 0) {
+		if (path.startsWith(subPath)) {
 			return path[subPath.length] === PATH_SEPARATOR;
 		}
 

--- a/lib/smart-clone/clone/clone-object.js
+++ b/lib/smart-clone/clone/clone-object.js
@@ -108,4 +108,8 @@ export default class CloneObject {
 			? this._isChanged
 			: this._onIsChanged(this.clone, value);
 	}
+
+	isPathApplicable(changePath) {
+		return path.isRootPath(this._path) || path.isSubPath(changePath, this._path);
+	}
 }

--- a/lib/smart-clone/smart-clone.js
+++ b/lib/smart-clone/smart-clone.js
@@ -81,6 +81,10 @@ export default class SmartClone {
 		return this._stack.at(-1).isChanged(isMutable, value, equals);
 	}
 
+	isPartOfClone(changePath) {
+		return this._stack.at(-1).isPathApplicable(changePath);
+	}
+
 	undo(object) {
 		if (this._previousClone !== undefined) {
 			this._previousClone.undo(object);

--- a/tests/on-change.test.js
+++ b/tests/on-change.test.js
@@ -828,3 +828,53 @@ test('array path should be the shorter one in the same object for circular refer
 	t.is(resultPath[1], '2');
 	t.is(resultPath[2], 'value');
 });
+
+test('should trigger when methods are called that mutate unrelated area of proxy when pathAsArray is false', t => {
+	const object = {
+		a: [
+			{
+				quantity: 1
+			}
+		],
+		b: {
+			c: {
+				quantity: 8,
+			},
+		}
+	};
+
+	testRunner(t, object, {pathAsArray: false}, (proxy, verify) => {
+		proxy.a.forEach(() => {
+			proxy.b.c = {
+				quantity: 3,
+			};
+		});
+
+		verify(1, proxy, 'b.c', { quantity: 3 }, { quantity: 8 });
+	});
+});
+
+test('should trigger when methods are called that mutate unrelated area of proxy when pathAsArray is true', t => {
+	const object = {
+		a: [
+			{
+				quantity: 1
+			}
+		],
+		b: {
+			c: {
+				quantity: 8,
+			},
+		}
+	};
+
+	testRunner(t, object, {pathAsArray: true}, (proxy, verify) => {
+		proxy.a.forEach(() => {
+			proxy.b.c = {
+				quantity: 3,
+			};
+		});
+
+		verify(1, proxy, ['b', 'c'], { quantity: 3 }, { quantity: 8 });
+	});
+});

--- a/tests/on-change.test.js
+++ b/tests/on-change.test.js
@@ -833,24 +833,25 @@ test('should trigger when methods are called that mutate unrelated area of proxy
 	const object = {
 		a: [
 			{
-				quantity: 1
-			}
+				quantity: 1,
+			},
 		],
 		b: {
 			c: {
 				quantity: 8,
 			},
-		}
+		},
 	};
 
 	testRunner(t, object, {pathAsArray: false}, (proxy, verify) => {
+		// eslint-disable-next-line unicorn/no-array-for-each
 		proxy.a.forEach(() => {
 			proxy.b.c = {
 				quantity: 3,
 			};
 		});
 
-		verify(1, proxy, 'b.c', { quantity: 3 }, { quantity: 8 });
+		verify(1, proxy, 'b.c', {quantity: 3}, {quantity: 8});
 	});
 });
 
@@ -858,23 +859,24 @@ test('should trigger when methods are called that mutate unrelated area of proxy
 	const object = {
 		a: [
 			{
-				quantity: 1
-			}
+				quantity: 1,
+			},
 		],
 		b: {
 			c: {
 				quantity: 8,
 			},
-		}
+		},
 	};
 
 	testRunner(t, object, {pathAsArray: true}, (proxy, verify) => {
+		// eslint-disable-next-line unicorn/no-array-for-each
 		proxy.a.forEach(() => {
 			proxy.b.c = {
 				quantity: 3,
 			};
 		});
 
-		verify(1, proxy, ['b', 'c'], { quantity: 3 }, { quantity: 8 });
+		verify(1, proxy, ['b', 'c'], {quantity: 3}, {quantity: 8});
 	});
 });


### PR DESCRIPTION
Hi,

I've been using your fantastic library in a side project, and I picked up an edge case that occurs when iterating over some part of the proxy and during that iteration modify a different part of the proxy. In this case the change path reported as the property currently being iterated over instead of the mutated property.

For example, if I have this object:
```
{
  a: [
    {
    quantity: 1
    }
  ],
  b: {
    c: {
      quantity: 8,
    },
  }
};
```

And I do the following:

```
proxy.a.forEach(() => {
  proxy.b.c = {
    quantity: 3,
  };
});
```

The expected change path is ```b.c```, however, it is reported as ```a```.

The issue seems to be that the ```handleChange``` would detect that a ```SmartClone``` is active, due to the ```forEach```, and therefore branch into the logic for updating the clone without first checking if the change path applies to the clone.
