### PR TITLE
fix: fix support for proxying `ArrayBuffer` and `SharedArrayBuffer`

### DIFF
--- a/source/is-builtin.js
+++ b/source/is-builtin.js
@@ -11,5 +11,7 @@ export function isBuiltinWithoutMutableMethods(value) {
 	// Primitives and null → true. Functions → false. RegExp → true.
 	return value === null
 		|| (typeof value !== 'object' && typeof value !== 'function')
-		|| value instanceof RegExp;
+		|| value instanceof RegExp
+		|| value instanceof ArrayBuffer
+		|| (typeof SharedArrayBuffer !== 'undefined' && value instanceof SharedArrayBuffer);
 }

--- a/tests/helpers/data-types.js
+++ b/tests/helpers/data-types.js
@@ -82,6 +82,11 @@ const typedArrays = [
 	new Float64Array([1, 2, 3]),
 ];
 
+const arrayBuffers = [
+	new ArrayBuffer(8),
+	new SharedArrayBuffer(8),
+];
+
 const nots = [undefined, null, Number.NaN];
 
 const testValues = [
@@ -98,6 +103,7 @@ const testValues = [
 	...weakSets,
 	...weakMaps,
 	...typedArrays,
+	...arrayBuffers,
 ];
 
 export {
@@ -116,4 +122,5 @@ export {
 	weakSets,
 	weakMaps,
 	typedArrays,
+	arrayBuffers,
 };

--- a/tests/is-builtin.test.js
+++ b/tests/is-builtin.test.js
@@ -15,9 +15,10 @@ import {
 	weakSets,
 	weakMaps,
 	typedArrays,
+	arrayBuffers,
 } from './helpers/data-types.js';
 
-const withoutMutableMethods = [...nots, ...booleans, ...numbers, ...strings, ...regExps];
+const withoutMutableMethods = [...nots, ...booleans, ...numbers, ...strings, ...regExps, ...arrayBuffers];
 const singleCollections = [sets[0], maps[0], weakSets[0], weakMaps[0]];
 
 for (const value of withoutMutableMethods) {

--- a/tests/on-change.arraybuffer.test.js
+++ b/tests/on-change.arraybuffer.test.js
@@ -46,7 +46,7 @@ test('ArrayBuffer in nested object should work', t => {
 	t.is(callCount, 0);
 });
 
-test('ArrayBuffer should be returned as-is (not proxied)', t => {
+test('ArrayBuffer should be returned as-is, not proxied', t => {
 	const buffer = new ArrayBuffer(8);
 	const object = {buffer};
 

--- a/tests/on-change.arraybuffer.test.js
+++ b/tests/on-change.arraybuffer.test.js
@@ -1,0 +1,96 @@
+import test from 'ava';
+import onChange from '../source/index.js';
+
+test('ArrayBuffer should not be proxied and byteLength should work', t => {
+	const buffer = new ArrayBuffer(16);
+	const object = {buffer};
+
+	let callCount = 0;
+	const proxy = onChange(object, () => {
+		callCount++;
+	});
+
+	t.is(proxy.buffer.byteLength, 16);
+	t.is(callCount, 0);
+});
+
+test('SharedArrayBuffer should not be proxied and byteLength should work', t => {
+	const buffer = new SharedArrayBuffer(24);
+	const object = {buffer};
+
+	let callCount = 0;
+	const proxy = onChange(object, () => {
+		callCount++;
+	});
+
+	t.is(proxy.buffer.byteLength, 24);
+	t.is(callCount, 0);
+});
+
+test('ArrayBuffer in nested object should work', t => {
+	const buffer = new ArrayBuffer(32);
+	const object = {
+		nested: {
+			data: {
+				buffer,
+			},
+		},
+	};
+
+	let callCount = 0;
+	const proxy = onChange(object, () => {
+		callCount++;
+	});
+
+	t.is(proxy.nested.data.buffer.byteLength, 32);
+	t.is(callCount, 0);
+});
+
+test('ArrayBuffer should be returned as-is (not proxied)', t => {
+	const buffer = new ArrayBuffer(8);
+	const object = {buffer};
+
+	const proxy = onChange(object, () => {});
+
+	t.is(proxy.buffer, buffer);
+});
+
+test('Replacing ArrayBuffer should trigger onChange', t => {
+	const buffer1 = new ArrayBuffer(8);
+	const buffer2 = new ArrayBuffer(16);
+	const object = {buffer: buffer1};
+
+	let callCount = 0;
+	const proxy = onChange(object, () => {
+		callCount++;
+	});
+
+	proxy.buffer = buffer2;
+	t.is(callCount, 1);
+	t.is(proxy.buffer.byteLength, 16);
+});
+
+test('TypedArray views should still be proxied', t => {
+	const uint8 = new Uint8Array([1, 2, 3]);
+	const object = {view: uint8};
+
+	let callCount = 0;
+	const proxy = onChange(object, () => {
+		callCount++;
+	});
+
+	t.is(proxy.view.length, 3);
+	t.is(proxy.view.byteLength, 3);
+
+	proxy.view[0] = 99;
+	t.is(callCount, 1);
+});
+
+test('ArrayBuffer from TypedArray.buffer should work', t => {
+	const uint8 = new Uint8Array(16);
+	const object = {view: uint8};
+
+	const proxy = onChange(object, () => {});
+
+	t.is(proxy.view.buffer.byteLength, 16);
+});


### PR DESCRIPTION
Fixes this error when proxying ArrayBuffers:

```
TypeError: Method get ArrayBuffer.prototype.byteLength called on incompatible receiver #<ArrayBuffer>
```
